### PR TITLE
Backport project to support java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ shadowJar {
   exclude 'module-info.class'
   exclude '**/module-info.class'
 
-  relocate 'com.google.code', 'xyz.zuoyx.multiyggdrasil.internal.com.google.code'
+  relocate 'com.google.gson', 'xyz.zuoyx.multiyggdrasil.internal.com.google.gson'
   relocate 'org.objectweb.asm', 'xyz.zuoyx.multiyggdrasil.internal.org.objectweb.asm'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,8 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.google.code.gson:gson:2.10.1'
+  implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'org.ow2.asm:asm:9.6'
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {
@@ -19,7 +18,8 @@ test {
 }
 
 compileJava {
-	options.release = 17
+  options.release = 8
+  options.deprecation = true
 }
 
 def buildNumber = System.getenv('AI_BUILD_NUMBER')
@@ -54,9 +54,14 @@ processResources {
 }
 
 shadowJar {
-	exclude 'META-INF/maven/**'
-	exclude 'module-info.class'
-	exclude '**/module-info.class'
+  archiveClassifier.set(null)
+
+  exclude 'META-INF/maven/**'
+  exclude 'module-info.class'
+  exclude '**/module-info.class'
+
+  relocate 'com.google.code', 'xyz.zuoyx.multiyggdrasil.internal.com.google.code'
+  relocate 'org.objectweb.asm', 'xyz.zuoyx.multiyggdrasil.internal.org.objectweb.asm'
 }
 
 defaultTasks 'clean', 'shadowJar'

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,92 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
+@if "%DEBUG%"=="" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if %ERRORLEVEL% equ 0 goto execute
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto execute
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+
+:end
+@rem End local scope for the variables with windows NT shell
+if %ERRORLEVEL% equ 0 goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/main/java/xyz/zuoyx/multiyggdrasil/Config.java
+++ b/src/main/java/xyz/zuoyx/multiyggdrasil/Config.java
@@ -74,14 +74,14 @@ public final class Config {
 		} else {
 			for (String option : prop.split(",")) {
 				switch (option) {
-					case "verbose" -> verboseLogging = true;
-					case "authlib" -> authlibLogging = true;
-					case "printUntransformed" -> {
+					case "verbose": verboseLogging = true;
+					case "authlib": authlibLogging = true;
+					case "printUntransformed": {
 						printUntransformedClass = true;
 						verboseLogging = true;
 					}
-					case "dumpClass" -> dumpClass = true;
-					default -> {
+					case "dumpClass": dumpClass = true;
+					default: {
 						log(ERROR, "Unrecognized debug option: " + option);
 						throw new InitializationException();
 					}
@@ -131,13 +131,12 @@ public final class Config {
 		int port = Integer.parseInt(matcher.group("port"));
 
 		switch (protocol) {
-			case "socks" -> mojangProxy = new Proxy(Type.SOCKS, new InetSocketAddress(host, port));
-			default -> {
+			case "socks": mojangProxy = new Proxy(Type.SOCKS, new InetSocketAddress(host, port));
+			default: {
 				log(ERROR, "Unsupported proxy protocol: " + protocol);
 				throw new InitializationException();
 			}
 		}
-		log(INFO, "Mojang proxy: " + mojangProxy);
 	}
 
 	private static FeatureOption parseFeatureOption(String property) {

--- a/src/main/java/xyz/zuoyx/multiyggdrasil/httpd/MultiQueryProfileFilter.java
+++ b/src/main/java/xyz/zuoyx/multiyggdrasil/httpd/MultiQueryProfileFilter.java
@@ -61,7 +61,7 @@ public class MultiQueryProfileFilter implements URLFilter {
 		if (!matcher.find())
 			throw new UnsupportedURLException();
 
-		UUID uuid;
+    		UUID uuid;
 		try {
 			uuid = fromUnsignedUUID(matcher.group("uuid"));
 		} catch (IllegalArgumentException e) {
@@ -78,9 +78,9 @@ public class MultiQueryProfileFilter implements URLFilter {
 		Optional<GameProfile> response;
 		if (uuid.version() == 4) {
 			response = mojangClient.queryProfile(uuid, withSignature);
-		} else {
+      		} else {
 			response = customClient.queryProfile(uuid, withSignature);
-			response.ifPresent(profile -> profile.name = new NamespacedID(profile.name, namespace).toString());
+      			response.ifPresent(profile -> profile.name = new NamespacedID(profile.name, namespace).toString());
 		}
 
 		if (response.isPresent()) {

--- a/src/main/java/xyz/zuoyx/multiyggdrasil/transform/ClassTransformer.java
+++ b/src/main/java/xyz/zuoyx/multiyggdrasil/transform/ClassTransformer.java
@@ -143,7 +143,7 @@ public class ClassTransformer implements ClassFileTransformer {
 			for (int i = units.length - 1; i >= 0; i--) {
 				TransformContextImpl ctx = new TransformContextImpl();
 				Optional<ClassVisitor> visitor = units[i].transform(classLoader, className, chain, ctx);
-				if (visitor.isEmpty())
+				if (!visitor.isPresent())
 					continue;
 				ctxs[i] = ctx;
 				chain = visitor.get();
@@ -287,7 +287,7 @@ public class ClassTransformer implements ClassFileTransformer {
 				handle.accept(unitsArray);
 
 				Optional<byte[]> transformResult = handle.finish();
-				if (Config.printUntransformedClass && transformResult.isEmpty()) {
+				if (Config.printUntransformedClass && !transformResult.isPresent()) {
 					log(DEBUG, "No transformation is applied to [" + className + "]");
 				}
 

--- a/src/main/java/xyz/zuoyx/multiyggdrasil/transform/LdcTransformUnit.java
+++ b/src/main/java/xyz/zuoyx/multiyggdrasil/transform/LdcTransformUnit.java
@@ -58,17 +58,18 @@ public abstract class LdcTransformUnit implements TransformUnit {
 						}
 					}
 
-					@Override
-					public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
-						for (int i = 0; i < bootstrapMethodArguments.length; i++) {
-							if (bootstrapMethodArguments[i] instanceof String constant) {
-								Optional<String> transformed = transformLdc(constant);
-								if (transformed.isPresent() && !transformed.get().equals(constant)) {
-									ctx.markModified();
-									bootstrapMethodArguments[i] = transformed.get();
-								}
-							}
-						}
+          @Override
+          public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+              for (int i = 0; i < bootstrapMethodArguments.length; i++) {
+                  if (bootstrapMethodArguments[i] instanceof String) {
+                      String constant = (String) bootstrapMethodArguments[i];
+                      Optional<String> transformed = transformLdc(constant);
+                      if (transformed.isPresent() && !transformed.get().equals(constant)) {
+                          ctx.markModified();
+                          bootstrapMethodArguments[i] = transformed.get();
+                      }
+                  }
+              }
 						super.visitInvokeDynamicInsn(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);
 					}
 				};

--- a/src/main/java/xyz/zuoyx/multiyggdrasil/util/JsonUtils.java
+++ b/src/main/java/xyz/zuoyx/multiyggdrasil/util/JsonUtils.java
@@ -28,37 +28,37 @@ import com.google.gson.reflect.TypeToken;
 
 public final class JsonUtils {
 
-	private static final Gson gson = new Gson();
+    private static final Gson gson = new Gson();
 
-	public static JsonElement parseJson(String jsonText) {
-		return JsonParser.parseString(jsonText);
-	}
+    public static JsonElement parseJson(String jsonText) {
+        return JsonParser.parseString(jsonText);
+    }
 
-	public static String toJsonString(Object json) {
-		return gson.toJson(json);
-	}
+    public static String toJsonString(Object json) {
+        return gson.toJson(json);
+    }
 
-	public static String asJsonString(JsonElement json) {
-		return json.getAsJsonPrimitive().getAsString();
-	}
-	public static boolean asBoolean(JsonElement json) {
-		if (json != null) {
-			return json.getAsJsonPrimitive().getAsBoolean();
-		} else {
-			return false;
-		}
-	}
+    public static String asJsonString(JsonElement json) {
+        return json.getAsJsonPrimitive().getAsString();
+    }
+    public static boolean asBoolean(JsonElement json) {
+        if (json != null) {
+            return json.getAsJsonPrimitive().getAsBoolean();
+        } else {
+            return false;
+        }
+    }
 
-	public static List<JsonElement> toJavaList(JsonArray json) {
-		Type listType = new TypeToken<List<JsonElement>>(){}.getType();
-		return gson.fromJson(json, listType);
-	}
+    public static List<JsonElement> toJavaList(JsonArray json) {
+        Type listType = new TypeToken<List<JsonElement>>(){}.getType();
+        return gson.fromJson(json, listType);
+    }
 
-	public static Map<String, JsonElement> toJavaMap(JsonObject json) {
-		Type mapType = new TypeToken<Map<String, JsonElement>>(){}.getType();
-		return gson.fromJson(json, mapType);
-	}
+    public static Map<String, JsonElement> toJavaMap(JsonObject json) {
+        Type mapType = new TypeToken<Map<String, JsonElement>>(){}.getType();
+        return gson.fromJson(json, mapType);
+    }
 
-	private JsonUtils() {}
+    private JsonUtils() {}
 
 }

--- a/src/main/java/xyz/zuoyx/multiyggdrasil/util/UnsupportedURLException.java
+++ b/src/main/java/xyz/zuoyx/multiyggdrasil/util/UnsupportedURLException.java
@@ -16,25 +16,22 @@
  */
 package xyz.zuoyx.multiyggdrasil.util;
 
-import java.io.Serial;
-
 public class UnsupportedURLException extends Exception {
-    @Serial
     private static final long serialVersionUID = 7895188952767140345L;
 
     public UnsupportedURLException() {
-        this(null, null);
+        super();
     }
 
     public UnsupportedURLException(String message) {
-        this(message, null);
+        super(message);
     }
 
     public UnsupportedURLException(String message, Throwable cause) {
-        super(message, cause, false, false);
+        super(message, cause);
     }
 
     public UnsupportedURLException(Throwable cause) {
-        this(null, cause);
+        super(cause);
     }
 }

--- a/src/main/java/xyz/zuoyx/multiyggdrasil/yggdrasil/NamespacedID.java
+++ b/src/main/java/xyz/zuoyx/multiyggdrasil/yggdrasil/NamespacedID.java
@@ -93,7 +93,8 @@ public class NamespacedID {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof NamespacedID other) {
+        if (obj instanceof NamespacedID) {
+            NamespacedID other = (NamespacedID) obj;
             return this.namespace.equals(other.namespace) && this.id.equals(other.id);
         }
         return false;


### PR DESCRIPTION
This not only fixes #11 but also allows MultiYggdrasil to support versions older than Minecraft 1.17. 

This also adds shadowjar remapping of asm and gson, allowing it to work with forge and older versions without overlapping libraries. (Which normal authlib-injector does for asm)

Everything works the same as It currently does, but it just replaces code that uses the newer java versions with code that works with java 8

I also added in portable gradle for people who don't have a system install of it

I've tested this on:
Vanilla 1.20.4
Vanilla 1.12.2
Vanilla 1.8.9
Forge 1.12.2

I feel like thats a good amount of testing to make sure it works with both new and old versions